### PR TITLE
Remove needless SUDO_PASSWORD for git.ruby-lang.org

### DIFF
--- a/bin/hocho
+++ b/bin/hocho
@@ -1,14 +1,5 @@
 #!/bin/bash
 prefix=()
 
-if [[ -z "$SUDO_PASSWORD" ]]; then
-  if which envchain > /dev/null 2>&1 && envchain --list | grep -q sudo; then
-    prefix=("envchain" "sudo")
-  else
-    echo "Environment variable \$SUDO_PASSWORD must be set."
-    echo "Retry this after installing envchain and running: envchain --set sudo SUDO_PASSWORD"
-    exit 1
-  fi
-fi
 
 exec "${prefix[@]}" bundle exec hocho "$@"


### PR DESCRIPTION
@k0kubun git.ruby-lang.org used shared `admin` user and this user can use `sudo` with `NOPASSWD`. Can we remove `SUDO_PASSWORD` check now?