### PR TITLE
Reduce cgit crawler load from abbreviated-SHA requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 repos/*
 /test/wc.orig/
 /test/repos.orig/
+/tmp/

--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -25,10 +25,16 @@
 
         TimeOut 300
 
-        # Alias /robots.txt "/var/www/git.ruby-lang.org/robots.txt"
         DocumentRoot /var/www/git.ruby-lang.org
 
         RewriteEngine On
+
+        # Serve robots.txt as a static file. cgit's "ScriptAlias /" would
+        # otherwise route it to cgit.cgi (returning 404), so crawlers never
+        # see the Disallow rule. mod_rewrite runs before mod_alias, so this
+        # bypasses the ScriptAlias.
+        RewriteRule ^/robots\.txt$ /var/www/git.ruby-lang.org/robots.txt [L]
+
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/(?:log|commit|diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/commit/%1 [R=302,L,NE,QSD]
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})

--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -29,11 +29,11 @@
         DocumentRoot /var/www/git.ruby-lang.org
 
         RewriteEngine On
-        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{40})
+        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/(?:log|commit|diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/commit/%1 [R=302,L,NE,QSD]
-        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{40})
+        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/tree/(.*)$ https://github.com/ruby/ruby/tree/%1/$1 [R=302,L,NE,QSD]
-        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{40})
+        RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/%1/$1 [R=302,L,NE,QSD]
         RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/master/$1 [R=302,L,NE,QSD]
 </VirtualHost>


### PR DESCRIPTION
git.ruby-lang.org repeatedly hit MaxRequestWorkers and stopped responding, including SSH, while crawler traffic dominated the server. On Jun 17 a single ClaudeBot IP made about 740k requests, roughly a third of the day's total, sustained near nine requests per second.

The existing GitHub redirect only matched a full 40-character id, but those crawler requests use 7 to 10 character abbreviated SHAs, so almost all of them fell through to expensive cgit rendering and returned 200. Matching {7,40} offloads them to GitHub instead.

robots.txt was also unreachable because cgit's ScriptAlias routed it to cgit.cgi and returned 404, so crawlers never received the Disallow rule. It is now served as a static file through mod_rewrite, which runs before mod_alias and bypasses the ScriptAlias.

The tmp/ entry keeps locally staged logs out of the repository.
