### PR TITLE
Drain Apache2 logs to Datadog via the Agent

### DIFF
--- a/recipes/datadog.rb
+++ b/recipes/datadog.rb
@@ -36,9 +36,9 @@ remote_file '/etc/datadog-agent/conf.d/apache.d/conf.yaml' do
 end
 
 # dd-agent needs the adm group to read /var/log/apache2 (root:adm, mode 640).
-group 'adm' do
-  members ['dd-agent']
-  append true
-  action :modify
+# mitamae's group resource cannot manage members, so add it via usermod.
+execute 'add dd-agent to adm group' do
+  command 'usermod -aG adm dd-agent'
+  not_if 'id -nG dd-agent | grep -qw adm'
   notifies :restart, 'service[datadog-agent]'
 end

--- a/recipes/datadog.rb
+++ b/recipes/datadog.rb
@@ -1,0 +1,44 @@
+service 'datadog-agent' do
+  action :nothing
+end
+
+execute 'systemctl daemon-reload (datadog)' do
+  command 'systemctl daemon-reload'
+  action :nothing
+end
+
+# Enable log collection via an environment override so the secret-bearing
+# datadog.yaml (API key, site) is left untouched.
+directory '/etc/systemd/system/datadog-agent.service.d' do
+  mode  '755'
+  owner 'root'
+end
+
+remote_file '/etc/systemd/system/datadog-agent.service.d/override.conf' do
+  mode  '644'
+  owner 'root'
+  notifies :run, 'execute[systemctl daemon-reload (datadog)]'
+  notifies :restart, 'service[datadog-agent]'
+end
+
+# Tail Apache2 access/error logs.
+directory '/etc/datadog-agent/conf.d/apache.d' do
+  mode  '755'
+  owner 'dd-agent'
+  group 'dd-agent'
+end
+
+remote_file '/etc/datadog-agent/conf.d/apache.d/conf.yaml' do
+  mode  '644'
+  owner 'dd-agent'
+  group 'dd-agent'
+  notifies :restart, 'service[datadog-agent]'
+end
+
+# dd-agent needs the adm group to read /var/log/apache2 (root:adm, mode 640).
+group 'adm' do
+  members ['dd-agent']
+  append true
+  action :modify
+  notifies :restart, 'service[datadog-agent]'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,6 +11,7 @@ include_recipe 'cgit'
 include_recipe 'git-user'
 include_recipe 'git-sync-user'
 include_recipe 'git-sync-check'
+include_recipe 'datadog'
 
 remote_file '/etc/sudoers'
 remote_file '/etc/locale.gen'

--- a/recipes/files/etc/datadog-agent/conf.d/apache.d/conf.yaml
+++ b/recipes/files/etc/datadog-agent/conf.d/apache.d/conf.yaml
@@ -3,6 +3,14 @@ logs:
     path: /var/log/apache2/other_vhosts_access.log
     service: git.ruby-lang.org
     source: apache
+    log_processing_rules:
+      # other_vhosts_access.log is vhost_combined, so each line starts with
+      # "vhost:port ". Strip that prefix so the line becomes standard combined
+      # and Datadog's Apache pipeline parses status/method/url/UA/client IP.
+      - type: mask_sequences
+        name: strip_vhost_prefix
+        replace_placeholder: ""
+        pattern: ^[A-Za-z0-9.-]+:[0-9]+\s
   - type: file
     path: /var/log/apache2/error.log
     service: git.ruby-lang.org

--- a/recipes/files/etc/datadog-agent/conf.d/apache.d/conf.yaml
+++ b/recipes/files/etc/datadog-agent/conf.d/apache.d/conf.yaml
@@ -1,0 +1,13 @@
+logs:
+  - type: file
+    path: /var/log/apache2/other_vhosts_access.log
+    service: git.ruby-lang.org
+    source: apache
+  - type: file
+    path: /var/log/apache2/error.log
+    service: git.ruby-lang.org
+    source: apache
+    log_processing_rules:
+      - type: multi_line
+        name: error_log_start_with_date
+        pattern: \[\w{3}\s\w{3}\s\d{2}

--- a/recipes/files/etc/systemd/system/datadog-agent.service.d/override.conf
+++ b/recipes/files/etc/systemd/system/datadog-agent.service.d/override.conf
@@ -1,0 +1,4 @@
+[Service]
+# Enable Datadog log collection without editing the secret-bearing datadog.yaml.
+# Equivalent to logs_enabled: true.
+Environment=DD_LOGS_ENABLED=true


### PR DESCRIPTION
Add a datadog mitamae recipe that ships git.ruby-lang.org's Apache access and error logs to Datadog. The Agent is already installed with its API key and site, so this only turns on log collection and adds the tail config. Logs are enabled through a DD_LOGS_ENABLED systemd override so the secret-bearing datadog.yaml is left untouched.

dd-agent is added to the adm group so it can read /var/log/apache2, which is root:adm mode 640. mitamae's group resource cannot manage members, so this is done with an idempotent usermod.

other_vhosts_access.log is vhost_combined, so each line is prefixed with "vhost:port" which the Datadog Apache pipeline's grok cannot match, leaving the request fields unparsed. The agent masks that prefix so lines become standard combined and status, method, url, user agent, and client IP are extracted as facets.

Verified on production. Access logs arrive under service:git.ruby-lang.org source:apache and @http.status_code and the related facets are populated.
