### PR TITLE
Redirect cgit ref browsing and range diffs to GitHub

### DIFF
--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -41,5 +41,21 @@
         RewriteRule ^/ruby\.git/tree/(.*)$ https://github.com/ruby/ruby/tree/%1/$1 [R=302,L,NE,QSD]
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/%1/$1 [R=302,L,NE,QSD]
+
+        # Range diffs (id2= without id=) are the heaviest cgit operation.
+        RewriteCond %{QUERY_STRING} (?:^|&)id2=([0-9a-fA-F]{7,40})
+        RewriteRule ^/ruby\.git/(?:diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/compare/%1...master [R=302,L,NE,QSD]
+
+        # Browse by ref (h=) -> GitHub, except branches under active
+        # development which we still want to browse on cgit.
+        RewriteCond %{QUERY_STRING} (?:^|&)h=(?!(?:master|ruby_3_[345]|ruby_4_0)(?:&|$))([^&]+)
+        RewriteRule ^/ruby\.git/log(?:/.*)?$ https://github.com/ruby/ruby/commits/%1 [R=302,L,NE,QSD]
+        RewriteCond %{QUERY_STRING} (?:^|&)h=(?!(?:master|ruby_3_[345]|ruby_4_0)(?:&|$))([^&]+)
+        RewriteRule ^/ruby\.git/(?:commit|diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/commit/%1 [R=302,L,NE,QSD]
+        RewriteCond %{QUERY_STRING} (?:^|&)h=(?!(?:master|ruby_3_[345]|ruby_4_0)(?:&|$))([^&]+)
+        RewriteRule ^/ruby\.git/tree/(.*)$ https://github.com/ruby/ruby/tree/%1/$1 [R=302,L,NE,QSD]
+        RewriteCond %{QUERY_STRING} (?:^|&)h=(?!(?:master|ruby_3_[345]|ruby_4_0)(?:&|$))([^&]+)
+        RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/%1/$1 [R=302,L,NE,QSD]
+        RewriteCond %{QUERY_STRING} !(?:^|&)h=
         RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/master/$1 [R=302,L,NE,QSD]
 </VirtualHost>


### PR DESCRIPTION
Distributed scrapers still overload cgit through URLs that bypass the existing `id=` redirect. During the 2026-07-18..21 incidents about 84k requests per 7 hours reached cgit, almost entirely `h=<ref>` browsing (60k) and `diff?id2=` range diffs (23k). This adds 302 redirects for both. `diff?id2=` goes to `compare/<id2>...master` on GitHub. `h=<ref>` requests for `log`, `commit`, `diff`, `patch`, `tree`, and `plain` go to the corresponding GitHub pages, except `master` and `ruby_3_3` through `ruby_4_0` which stay browsable on cgit. Observed `h=` values are almost entirely old tags and EOL branches, so the exclusion barely reduces the offload. The unconditional `plain` fallback to `raw/master` now applies only when no `h=` is present so excluded branches serve correct content.

Generated with [Claude Code](https://claude.com/claude-code)
