### PR TITLE
Match the updated merge commit rejection message

### DIFF
--- a/test/test-pre-receive.rb
+++ b/test/test-pre-receive.rb
@@ -97,7 +97,7 @@ class TestPreReceive < Test::Unit::TestCase
     make_commit("mame", "mame@ruby-lang.org", "e")
     err = git("push") rescue $!
     assert_match(
-      /A merge commit is prohibited\./,
+      /A merge commit is prohibited for refs\/heads\/master\./,
       err.message
     )
   end


### PR DESCRIPTION
`test_prohibit_merge_commit` has been failing on `master` since 77967dc, which started including the refname in the message printed by `bin/prohibit-merge-commits.rb`. The test regex still required a period immediately after `prohibited`, so it stopped matching. The assertion now expects the full message including `refs/heads/master`.

The stable branch exemption added by that same commit remains untested. I left that out of this change.
