### PR TITLE
Relax the last ref redirect and fix two front vhost routes

### DIFF
--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -63,6 +63,16 @@
         RewriteCond %{HTTP_USER_AGENT} (AI2Bot|Amazonbot|anthropic-ai|Bytespider|ChatGPT-User|ClaudeBot|Claude-SearchBot|Claude-User|cohere-ai|Diffbot|FacebookBot|GPTBot|ICC-Crawler|ImagesiftBot|img2dataset|meta-externalagent|meta-externalfetcher|meta-webindexer|MistralAI-User|OAI-SearchBot|omgili|PanguBot|PerplexityBot|Perplexity-User|PetalBot|Scrapy|SemrushBot|Timpibot|VelenPublicWebCrawler|YouBot) [NC]
         RewriteRule ^ - [F,L]
 
+        # Browse by commit id -> GitHub. Browsing by ref (h=) went back to
+        # cgit on 2026-08-31; these three rules and the id2= one below are all
+        # that is left.
+        #
+        # Anubis validated 24,407 of the 266,560 challenges it issued between
+        # 2026-08-19 and 08-31, so budget 9% of a rule's traffic as work cgit
+        # will actually do. Measured over 08-24 to 08-30 that is 194 req/h
+        # (id= plain), 238 (id= log/commit/diff/patch) and 463 (id= tree)
+        # against the 82 req/h cgit renders today. Relax one rule at a time
+        # and measure in between.
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/(?:log|commit|diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/commit/%1 [R=302,L,NE,QSD]
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
@@ -70,25 +80,11 @@
         RewriteCond %{QUERY_STRING} (?:^|&)id=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/plain/(.*)$ https://github.com/ruby/ruby/raw/%1/$1 [R=302,L,NE,QSD]
 
-        # Range diffs (id2= without id=) are the heaviest cgit operation.
+        # Range diffs (id2= without id=) are the heaviest cgit operation,
+        # but only 5 req/h ask for one, so relaxing this alone would
+        # measure nothing.
         RewriteCond %{QUERY_STRING} (?:^|&)id2=([0-9a-fA-F]{7,40})
         RewriteRule ^/ruby\.git/(?:diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/compare/%1...master [R=302,L,NE,QSD]
-
-        # Browse by ref (h=) -> GitHub, except branches under active
-        # development which we still want to browse on cgit.
-        #
-        # tree, plain and log by ref are served by cgit again, behind Anubis,
-        # along with the plain view that used to fall back to raw/master.
-        #
-        # Anubis validates 478 of every 1250 challenges it issues, so budget
-        # 38% of a rule's traffic as work cgit will actually do. What is left
-        # here costs 1,463 req/h (h= commit/diff/patch), 546 (id2= range
-        # diffs), 617 (id= plain), 2,765 (id= tree) and 8,561 (id=
-        # log/commit/diff/patch) against the 1,764 req/h cgit renders today.
-        # The last one alone is a 5.9x increase, so relax one rule at a time
-        # and measure in between.
-        RewriteCond %{QUERY_STRING} (?:^|&)h=(?!(?:master|ruby_3_[345]|ruby_4_0)(?:&|$))([^&]+)
-        RewriteRule ^/ruby\.git/(?:commit|diff|patch)(?:/.*)?$ https://github.com/ruby/ruby/commit/%1 [R=302,L,NE,QSD]
 
         # Everything past this point is proxied. The redirects above run first
         # on purpose: traffic we hand to GitHub should never pay for a

--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -49,6 +49,14 @@
 
         RewriteEngine On
 
+        # This is the first *:443 vhost apache reads, so it also answers for
+        # every other name pointed at this host that has no vhost of its own,
+        # ci.ruby-lang.org and cvs.ruby-lang.org among them. Anubis scopes its
+        # cookie to COOKIE_DOMAIN, so a client challenged under one of those
+        # names comes back without the cookie and loops on 500s.
+        RewriteCond %{HTTP_HOST} !^git\.ruby-lang\.org(?::443)?$ [NC]
+        RewriteRule ^ - [F,L]
+
         # Serve robots.txt as a static file. cgit's "ScriptAlias /" would
         # otherwise route it to cgit.cgi (returning 404), so crawlers never
         # see the Disallow rule. mod_rewrite runs before mod_alias, so this

--- a/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
+++ b/recipes/files/etc/apache2/sites-available/git.ruby-lang.org.conf
@@ -63,6 +63,13 @@
         # bypasses the ScriptAlias.
         RewriteRule ^/robots\.txt$ /var/www/git.ruby-lang.org/robots.txt [L]
 
+        # cgit links to /favicon.ico from every page and ships one in
+        # /usr/share/cgit, but the same "ScriptAlias /" swallows that path too,
+        # so it has been 404ing through Anubis and the backend instead. Serving
+        # it here also keeps the noise out of cgit_backend_access.log, which is
+        # what the redirect steps are measured against.
+        RewriteRule ^/favicon\.ico$ /usr/share/cgit/favicon.ico [L]
+
         # Crawlers that name themselves, refused before they cost us anything.
         # Anubis denies these too, but this also covers the git clone paths,
         # which are routed around Anubis. It does nothing about the ~85% of the


### PR DESCRIPTION
Third step of walking the GitHub redirects back. Anubis validated 24,407 of the 266,560 challenges it issued in the twelve days since the catch-all rule closed the non-Mozilla hole, so the 848 req/h this rule redirects should land as roughly 78 req/h of cgit rendering against the 82 req/h it does today. Dropping it also removes the branch exclusion list.

The other two commits touch the same vhost. `ci.ruby-lang.org` and `cvs.ruby-lang.org` resolve here without a vhost of their own, and clients challenged under those names loop on 500s because Anubis scopes its cookie to `COOKIE_DOMAIN`. Separately, cgit links to `/favicon.ico` from every page but `ScriptAlias /` swallows the path, so it has been 404ing through Anubis into `cgit_backend_access.log`, which is the log each redirect step is measured against.

I ran these rules in a throwaway apache built from this file. `git.ruby-lang.org` is served while `ci.ruby-lang.org`, the bare IP and a `Host`-less `HTTP/1.0` request get 403. `/favicon.ico` returns the shipped icon, clone paths and `?id=` redirects are unchanged, and `/ruby.git/commit/?h=v3_4_0_rc1` now reaches cgit.
